### PR TITLE
fix: size message bubble to content instead of stretching full width

### DIFF
--- a/client/src/app/main/debate/[roomId]/page.tsx
+++ b/client/src/app/main/debate/[roomId]/page.tsx
@@ -297,7 +297,7 @@ const ChatPage: React.FC<ChatPageProps> = () => {
 
 
                           <div
-                            className={`min-w-0 max-w-[calc(100%-3rem)] md:max-w-[75%] ${isOwnMessage ? "ml-auto" : ""}`}
+                            className={`min-w-0 w-fit max-w-[calc(100%-3rem)] md:max-w-[60%] ${isOwnMessage ? "ml-auto" : ""}`}
                           >
                             <div
                               className={`flex items-center gap-2 mb-1 ${isOwnMessage ? "flex-row-reverse" : ""}`}


### PR DESCRIPTION
Fixes #58

## 📋 Pull Request Description
**Summary**
Message bubbles were stretching to fill the full width of the chat container regardless of how short the message content was. This PR makes the bubble size to its content, capped at a reasonable maximum width.

**Related Issues**
Fixes #58

## 🔄 Type of Change
- [x] 🎨 Style/UI changes

## 🧪 How Has This Been Tested?
- [x] Manual testing (code review of rendered className logic)

**Test Configuration:**
- Node.js version: 18+
- Browser: N/A (not run live — see note below)
- OS: Windows

**Note:** I reviewed the change carefully against the component logic but wasn't able to fully verify it live locally due to a Postgres/Docker environment issue unrelated to this fix. The change itself is a single Tailwind className edit with no logic changes, so risk is low, but flagging this for reviewers to double check visually if possible.

## 📷 Screenshots (if applicable)
**Before:**
See the original issue screenshot — short messages stretch across most of the row.

**After:**
(not captured locally — happy to add if requested)

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## 📝 Additional Notes
**Root cause:** the message bubble wrapper `div` only set a `max-width` (`max-w-[calc(100%-3rem)] md:max-w-[75%]`), never an actual `width`. As a block-level flex child, it always expanded to fill the available row space, so even a two-word message stretched to the max-width cap.

**Fix:** added `w-fit` so the bubble sizes to its content instead of stretching, and tightened the desktop cap from 75% to 60% to match the issue's suggested 50–60% range. Long messages still wrap correctly since `break-words` was already applied to the bubble content, so this doesn't introduce overflow.

**Breaking Changes:** None — purely visual, no logic or API changes.

**Dependencies:** None.